### PR TITLE
Fix unused argument in "06-data-carpentry.Rmd" (#312)

### DIFF
--- a/06-data-carpentry.Rmd
+++ b/06-data-carpentry.Rmd
@@ -544,8 +544,8 @@ library(rlang)
 group_by(cars, speed = cut(speed, c(0, 10, 100))) %>%
   summarise(mean_dist = mean(dist))
 # 2: Evaluation from character string
-group_by(cars, speed = !!parse_expr("cut(speed, c(0, 10, 100))", env = caller_env())) %>%
-  summarise(mean_dist = !!parse_expr("mean(dist)", env = caller_env()))
+group_by(cars, speed = !!parse_expr("cut(speed, c(0, 10, 100))")) %>%
+  summarise(mean_dist = !!parse_expr("mean(dist)"))
 # 3: Using !! to evaluate 'quosures' when appropriate
 q1 = quo(cut(speed, c(0, 10, 100)))
 q2 = quo(mean(dist))


### PR DESCRIPTION
* Fix unused argument

Fix for the error:

Quitting from lines 3388-3400 (_main.Rmd)
Error in parse_expr("cut(speed, c(0, 10, 100))", env = caller_env()) :
  unused argument (env = caller_env())
Calls: <Anonymous> ... group_by_prepare -> enquos -> endots -> map -> lapply -> FUN -> splice

* Update .gitignore

* Update .gitignore

* Add epub format option

* Revert "Update .gitignore"

This reverts commit 1c51c9e2aba5a7f30e4bbea1c619a6349faf27a6.

* Revert "Update .gitignore"

This reverts commit b1de326237a60316059c2917c94f65ce1a20f135.

* Revert "Add epub format option"

This reverts commit afbb01f8fa9f986de616f630472613da69973edf.